### PR TITLE
feat(roadmap): add block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor/
 node_modules/
 spa/build/
+/build/
 composer.lock
 package-lock.json
 .phpunit.cache/

--- a/app/Blocks/roadmap/block.json
+++ b/app/Blocks/roadmap/block.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "easyroadmap/roadmap",
+	"version": "0.1.0",
+	"title": "Roadmap",
+	"category": "widgets",
+	"icon": "calendar-alt",
+	"description": "Roadmap block",
+	"example": {},
+	"supports": {
+		"html": false
+	},
+	"textdomain": "easyroadmap",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"render": "file:./render.php"
+}

--- a/app/Blocks/roadmap/edit.js
+++ b/app/Blocks/roadmap/edit.js
@@ -1,0 +1,38 @@
+/**
+ * Retrieves the translation of text.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * Those files can contain any CSS code that gets applied to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './editor.scss';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {Element} Element to render.
+ */
+export default function Edit() {
+	return (
+		<p { ...useBlockProps() }>
+			{ __( 'Roadmap – choose a product in the settings if you want', 'easyroadmap' ) }
+		</p>
+	);
+}

--- a/app/Blocks/roadmap/editor.scss
+++ b/app/Blocks/roadmap/editor.scss
@@ -1,0 +1,9 @@
+/**
+ * The following styles get applied inside the editor only.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-easyroadmap-roadmap {
+	border: 1px dotted #f00;
+}

--- a/app/Blocks/roadmap/index.js
+++ b/app/Blocks/roadmap/index.js
@@ -1,0 +1,24 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+} );

--- a/app/Blocks/roadmap/render.php
+++ b/app/Blocks/roadmap/render.php
@@ -3,7 +3,8 @@
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 
-use EasyRoadmap\Controller\Common\Roadmap;
+use EasyRoadmap\Model\Roadmap;
+
 
 //TODO: add product attribute
 //echo get_block_wrapper_attributes();

--- a/app/Blocks/roadmap/render.php
+++ b/app/Blocks/roadmap/render.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
+ */
+
+use EasyRoadmap\Controller\Common\Roadmap;
+
+//TODO: add product attribute
+//echo get_block_wrapper_attributes();
+?>
+
+<?php echo Roadmap::get_roadmap(); ?>

--- a/app/Controller/Common/Blocks.php
+++ b/app/Controller/Common/Blocks.php
@@ -1,0 +1,46 @@
+<?php
+namespace EasyRoadmap\Controller\Common;
+
+defined( 'ABSPATH' ) || exit;
+
+class Blocks {
+	/**
+	 * Constructor to add all blocks.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'easyroadmap_blocks_init' ] );
+	}
+
+	public function easyroadmap_blocks_init() {
+		/**
+		 * Registers the block(s) metadata from the `blocks-manifest.php` and registers the block type(s)
+		 * based on the registered block metadata.
+		 * Added in WordPress 6.8 to simplify the block metadata registration process added in WordPress 6.7.
+		 *
+		 * @see https://make.wordpress.org/core/2025/03/13/more-efficient-block-type-registration-in-6-8/
+		 */
+		if ( function_exists( 'wp_register_block_types_from_metadata_collection' ) ) {
+			wp_register_block_types_from_metadata_collection( EASYROADMAP_PLUGIN_DIR . '/build', EASYROADMAP_PLUGIN_DIR . '/build/blocks-manifest.php' );
+			return;
+		}
+
+		/**
+		 * Registers the block(s) metadata from the `blocks-manifest.php` file.
+		 * Added to WordPress 6.7 to improve the performance of block type registration.
+		 *
+		 * @see https://make.wordpress.org/core/2024/10/17/new-block-type-registration-apis-to-improve-performance-in-wordpress-6-7/
+		 */
+		if ( function_exists( 'wp_register_block_metadata_collection' ) ) {
+			wp_register_block_metadata_collection( EASYROADMAP_PLUGIN_DIR . '/build', EASYROADMAP_PLUGIN_DIR . '/build/blocks-manifest.php' );
+		}
+		/**
+		 * Registers the block type(s) in the `blocks-manifest.php` file.
+		 *
+		 * @see https://developer.wordpress.org/reference/functions/register_block_type/
+		 */
+		$manifest_data = require EASYROADMAP_PLUGIN_DIR . '/build/blocks-manifest.php';
+		foreach ( array_keys( $manifest_data ) as $block_type ) {
+			register_block_type( EASYROADMAP_PLUGIN_DIR . "/build/{$block_type}" );
+		}
+	}
+}

--- a/app/Controller/Common/Roadmap.php
+++ b/app/Controller/Common/Roadmap.php
@@ -1,0 +1,54 @@
+<?php
+namespace EasyRoadmap\Controller\Common;
+
+defined( 'ABSPATH' ) || exit;
+
+use EasyRoadmap\Helper\Utility;
+
+class Roadmap {
+
+    public static function get_roadmap( $product = null ) {
+        $tasks  = array();
+		$stages = get_terms(
+			array(
+				'taxonomy'   => 'task_stage',
+				'hide_empty' => false,
+				'orderby'    => 'id',
+				'order'      => 'ASC',
+			)
+		);
+
+		foreach ( $stages as $stage ) {
+			$tasks[ $stage->slug ]['id']   = $stage->term_id;
+			$tasks[ $stage->slug ]['name'] = $stage->name;
+
+			$tax_query = array();
+
+			$tax_query[] = array(
+				'taxonomy' => 'task_stage',
+				'field'    => 'slug',
+				'terms'    => $stage->slug,
+			);
+
+			if ( ! is_null( $product ) ) {
+				$tax_query[] = array(
+					'taxonomy' => 'task_product',
+					'field'    => 'term_id',
+					'terms'    => $product,
+				);
+			}
+
+			$tasks[ $stage->slug ]['tasks'] = Utility::get_posts(
+				array(
+					'post_type'      => 'task',
+					'tax_query'      => $tax_query,
+					'posts_per_page' => -1,
+					'orderby'        => 'menu_order',
+					'order'          => 'ASC',
+				)
+			);
+		}
+
+		return Utility::get_template( 'shortcodes/roadmap.php', array( 'tasks' => $tasks ) );
+    }
+}

--- a/app/Controller/Public/Shortcode.php
+++ b/app/Controller/Public/Shortcode.php
@@ -3,8 +3,8 @@ namespace EasyRoadmap\Controller\Public;
 
 defined( 'ABSPATH' ) || exit;
 
+use EasyRoadmap\Controller\Common\Roadmap;
 use EasyRoadmap\Trait\Hook;
-use EasyRoadmap\Helper\Utility;
 
 class Shortcode {
 
@@ -19,48 +19,7 @@ class Shortcode {
 
 	public function callback_roadmap( $atts ) {
 		$atts = shortcode_atts( array( 'product' => null ), $atts, 'roadmap' );
-
-		$tasks  = array();
-		$stages = get_terms(
-			array(
-				'taxonomy'   => 'task_stage',
-				'hide_empty' => false,
-				'orderby'    => 'id',
-				'order'      => 'ASC',
-			)
-		);
-
-		foreach ( $stages as $stage ) {
-			$tasks[ $stage->slug ]['id']   = $stage->term_id;
-			$tasks[ $stage->slug ]['name'] = $stage->name;
-
-			$tax_query = array();
-
-			$tax_query[] = array(
-				'taxonomy' => 'task_stage',
-				'field'    => 'slug',
-				'terms'    => $stage->slug,
-			);
-
-			if ( ! is_null( $atts['product'] ) ) {
-				$tax_query[] = array(
-					'taxonomy' => 'task_product',
-					'field'    => 'term_id',
-					'terms'    => $atts['product'],
-				);
-			}
-
-			$tasks[ $stage->slug ]['tasks'] = Utility::get_posts(
-				array(
-					'post_type'      => 'task',
-					'tax_query'      => $tax_query,
-					'posts_per_page' => -1,
-					'orderby'        => 'menu_order',
-					'order'          => 'ASC',
-				)
-			);
-		}
-
-		return Utility::get_template( 'shortcodes/roadmap.php', array( 'tasks' => $tasks ) );
+		$product = $atts[ 'product' ] ?? null;
+		Roadmap::get_roadmap( $product );
 	}
 }

--- a/app/Controller/Public/Shortcode.php
+++ b/app/Controller/Public/Shortcode.php
@@ -20,6 +20,7 @@ class Shortcode {
 	public function callback_roadmap( $atts ) {
 		$atts = shortcode_atts( array( 'product' => null ), $atts, 'roadmap' );
 		$product = $atts[ 'product' ] ?? null;
-		Roadmap::get_roadmap( $product );
+		
+		return Roadmap::get_roadmap( $product );
 	}
 }

--- a/app/Controller/Public/Shortcode.php
+++ b/app/Controller/Public/Shortcode.php
@@ -3,7 +3,7 @@ namespace EasyRoadmap\Controller\Public;
 
 defined( 'ABSPATH' ) || exit;
 
-use EasyRoadmap\Controller\Common\Roadmap;
+use EasyRoadmap\Model\Roadmap;
 use EasyRoadmap\Trait\Hook;
 
 class Shortcode {

--- a/app/Model/Roadmap.php
+++ b/app/Model/Roadmap.php
@@ -1,5 +1,5 @@
 <?php
-namespace EasyRoadmap\Controller\Common;
+namespace EasyRoadmap\Model;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
     "build:admin": "webpack --config webpack.config.admin.js",
     "build:public": "webpack --config webpack.config.public.js",
     "build:css": "webpack --config webpack.config.js",
+    "build:blocks": "wp-scripts build --source-path=app/Blocks --webpack-copy-php --blocks-manifest",
     "start": "webpack serve --config webpack.config.dev.js",
+    "start:blocks": "wp-scripts start --webpack-copy-php --blocks-manifest",
     "watch": "webpack --watch"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",
     "@babel/preset-env": "^7.24.5",
     "@babel/preset-react": "^7.24.1",
+    "@wordpress/scripts": "^30.19.0",
     "babel-loader": "^9.1.3",
     "clean-webpack-plugin": "^4.0.0",
     "html-webpack-plugin": "^5.6.0",


### PR DESCRIPTION
closes #8 

First version without `product` setting.

Use the script `npm run build:blocks` to build the block.
The `/build/` folder will be in root (can be adjusted of course).
Did not know if you want to have the build folder in the repo.